### PR TITLE
MODOKAPFAC-6 Fix feign client config

### DIFF
--- a/src/main/java/org/folio/okapi/facade/integration/ma/MgrApplicationsClient.java
+++ b/src/main/java/org/folio/okapi/facade/integration/ma/MgrApplicationsClient.java
@@ -11,8 +11,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "application",
-  url = "${application.mt.url}",
-  configuration = MgrApplicationsClientProperties.class)
+  url = "${application.ma.url}",
+  configuration = MgrApplicationsClientConfiguration.class)
 public interface MgrApplicationsClient {
 
   @GetMapping(value = "/applications", consumes = APPLICATION_JSON_VALUE)


### PR DESCRIPTION
## Purpose
Fix mgr-applications feign client configuration
US: [MODOKAPFAC-6](https://folio-org.atlassian.net/browse/MODOKAPFAC-6)

## Approach
* correct feign client url and configuration class