### PR TITLE
EPC. The Jenkins part has been switched to the folio_jenkins_shared_libs EPC branch to ensure an update of the eureka-platform.json file in the platform-complete repository.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,7 @@
+import org.jenkinsci.plugins.workflow.libs.Library
+
+@Library('folio_jenkins_shared_libs@EPC') _
+
 buildMvn {
   publishModDescriptor = true
   mvnDeploy = true


### PR DESCRIPTION
## Purpose

The platform-complete repository contains the eureka-platform.json file in the snapshot branch. This file is used to deploy the snapshot Eureka environment on Rancher. There is some code located in the folio_jenkins_shared_libs EPC branch that is used to update the eureka-platform.json file. Therefore, it is crucial to switch to that branch to ensure the file is updated.
