### PR TITLE
fix(deps): MODOKAPFAC-13: Spring Boot 3.3.5, folio-spring-base 8.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5</version>
     <relativePath />
   </parent>
 
@@ -34,7 +34,7 @@
     <openapi-tools.jackson-databind-nullable.version>0.2.6</openapi-tools.jackson-databind-nullable.version>
     <mapstruct.version>1.6.2</mapstruct.version>
     <hypersistence-utils-hibernate-63.version>3.8.2</hypersistence-utils-hibernate-63.version>
-    <folio-spring-support.version>8.2.0</folio-spring-support.version>
+    <folio-spring-support.version>8.2.1</folio-spring-support.version>
     <folio-java-checkstyle.version>1.0.1</folio-java-checkstyle.version>
     <applications-poc-tools.version>2.0.0</applications-poc-tools.version>
     <coffee-boots.version>4.0.0</coffee-boots.version>
@@ -43,14 +43,14 @@
     </okapi-facade.yaml-file>
 
     <!-- Test dependencies versions -->
-    <testcontainer.version>1.20.2</testcontainer.version>
+    <testcontainer.version>1.20.3</testcontainer.version>
     <instancio.version>5.0.2</instancio.version>
     <kryo.version>5.6.0</kryo.version>
 
     <!-- Plugins versions -->
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-checkstyle.version>10.18.2</maven-checkstyle.version>
-    <maven-checkstyle-plugin.version>3.5.0</maven-checkstyle-plugin.version>
+    <maven-checkstyle.version>10.20.0</maven-checkstyle.version>
+    <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
     <openapi-generator.version>7.9.0</openapi-generator.version>

--- a/src/test/java/org/folio/okapi/facade/controller/ApiExceptionHandlerTest.java
+++ b/src/test/java/org/folio/okapi/facade/controller/ApiExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package org.folio.okapi.facade.controller;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.when;
@@ -167,7 +168,7 @@ class ApiExceptionHandlerTest {
         .header(CACHE_CONTROL, "no-cache"))
       .andExpect(status().isBadRequest())
       .andExpect(jsonPath("$.total_records", is(1)))
-      .andExpect(jsonPath("$.errors[0].message", startsWith(errorMessage)))
+      .andExpect(jsonPath("$.errors[0].message", containsString(errorMessage)))
       .andExpect(jsonPath("$.errors[0].type", is("MethodArgumentTypeMismatchException")))
       .andExpect(jsonPath("$.errors[0].code", is("validation_error")));
   }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODOKAPFAC-13

## Purpose
Fix a tomcat-embed-core vulnerability (request/response mix-up between users): https://nvd.nist.gov/vuln/detail/CVE-2024-52317

For Ramsons.

## Approach
Upgrade Spring Boot from 3.3.4 to 3.3.5 and upgrade folio-spring-base from 8.2.0 to 8.2.1.

The fix had been merged to master branch: https://github.com/folio-org/mod-okapi-facade/pull/31

This is the back-port to the Ramsons branch b2.0.

## TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.

(cherry picked from commit 63f7edf71d08c9c8e280420202b34553222dbf48)