### PR TITLE
MODOKAPFAC-11: add system token if exists while module search

### DIFF
--- a/src/main/java/org/folio/okapi/facade/controller/ProxyTenantInterfaceController.java
+++ b/src/main/java/org/folio/okapi/facade/controller/ProxyTenantInterfaceController.java
@@ -1,5 +1,7 @@
 package org.folio.okapi.facade.controller;
 
+import static org.folio.okapi.facade.utils.TokenUtils.extractToken;
+
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.folio.common.domain.model.InterfaceDescriptor;
@@ -21,7 +23,7 @@ public class ProxyTenantInterfaceController implements ProxyTenantInterfaceApi {
   @Override
   public ResponseEntity<List<InterfaceDescriptor>> getAllInterfaces(String tenantId, Boolean full, String type) {
     return ResponseEntity.ofNullable(
-      tenantInterfacesService.getTenantInterfaces(folioExecutionContext.getToken(), tenantId, full != null && full,
+      tenantInterfacesService.getTenantInterfaces(extractToken(folioExecutionContext), tenantId, full != null && full,
         type));
   }
 

--- a/src/main/java/org/folio/okapi/facade/service/TenantModuleService.java
+++ b/src/main/java/org/folio/okapi/facade/service/TenantModuleService.java
@@ -32,7 +32,7 @@ public class TenantModuleService {
   @SuppressWarnings("java:S107")
   public List<ModuleDescriptor> findAll(String tenantId, String filter, boolean full, Integer latest,
     String order, String orderBy, String provide, String require, String scope, String preRelease, String npmSnapshot) {
-    var token = folioContext.getToken(); // the token is not required by the target endpoint for now
+    var token = extractToken(folioContext);
     var apps = entitlementService.getTenantApplications(tenantId, token);
 
     var mdFilter = createFilter(filter, provide, require, scope, preRelease, npmSnapshot);
@@ -148,5 +148,9 @@ public class TenantModuleService {
       }
       throw new IllegalArgumentException("invalid order value: " + value);
     }
+  }
+
+  private static String extractToken(FolioExecutionContext folioContext) {
+    return folioContext.getAllHeaders().get("x-system-token").stream().findFirst().orElse(folioContext.getToken());
   }
 }

--- a/src/main/java/org/folio/okapi/facade/service/TenantModuleService.java
+++ b/src/main/java/org/folio/okapi/facade/service/TenantModuleService.java
@@ -151,6 +151,8 @@ public class TenantModuleService {
   }
 
   private static String extractToken(FolioExecutionContext folioContext) {
-    return folioContext.getAllHeaders().get("x-system-token").stream().findFirst().orElse(folioContext.getToken());
+    return toStream(folioContext.getAllHeaders().get("x-system-token"))
+      .findFirst()
+      .orElse(folioContext.getToken());
   }
 }

--- a/src/main/java/org/folio/okapi/facade/service/TenantModuleService.java
+++ b/src/main/java/org/folio/okapi/facade/service/TenantModuleService.java
@@ -6,6 +6,7 @@ import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.folio.common.utils.CollectionUtils.mapItems;
 import static org.folio.common.utils.CollectionUtils.toStream;
+import static org.folio.okapi.facade.utils.TokenUtils.extractToken;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -148,11 +149,5 @@ public class TenantModuleService {
       }
       throw new IllegalArgumentException("invalid order value: " + value);
     }
-  }
-
-  private static String extractToken(FolioExecutionContext folioContext) {
-    return toStream(folioContext.getAllHeaders().get("x-system-token"))
-      .findFirst()
-      .orElse(folioContext.getToken());
   }
 }

--- a/src/main/java/org/folio/okapi/facade/utils/TokenUtils.java
+++ b/src/main/java/org/folio/okapi/facade/utils/TokenUtils.java
@@ -1,0 +1,18 @@
+package org.folio.okapi.facade.utils;
+
+import static org.folio.common.utils.CollectionUtils.toStream;
+
+import lombok.experimental.UtilityClass;
+import org.folio.spring.FolioExecutionContext;
+
+@UtilityClass
+public class TokenUtils {
+
+  public static final String SYSTEM_TOKEN = "X-System-Token";
+
+  public static String extractToken(FolioExecutionContext folioContext) {
+    return toStream(folioContext.getAllHeaders().get(SYSTEM_TOKEN))
+      .findFirst()
+      .orElse(folioContext.getToken());
+  }
+}

--- a/src/test/java/org/folio/okapi/facade/service/TenantModuleServiceTest.java
+++ b/src/test/java/org/folio/okapi/facade/service/TenantModuleServiceTest.java
@@ -6,6 +6,7 @@ import static org.apache.commons.collections4.ListUtils.union;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.folio.common.utils.CollectionUtils.toStream;
+import static org.folio.okapi.facade.utils.TokenUtils.SYSTEM_TOKEN;
 import static org.folio.test.TestConstants.OKAPI_AUTH_TOKEN;
 import static org.folio.test.TestConstants.TENANT_ID;
 import static org.folio.test.TestUtils.parse;
@@ -90,7 +91,7 @@ class TenantModuleServiceTest {
 
   @Test
   void findAll_positive_defaultParams_systemTokenExists() {
-    when(folioContext.getAllHeaders()).thenReturn(Map.of("x-system-token", List.of("systemToken")));
+    when(folioContext.getAllHeaders()).thenReturn(Map.of(SYSTEM_TOKEN, List.of("systemToken")));
     when(entitlementService.getTenantApplications(tenantId, "systemToken")).thenReturn(testAppDescriptors);
     var found = findAll();
 

--- a/src/test/java/org/folio/okapi/facade/service/TenantModuleServiceTest.java
+++ b/src/test/java/org/folio/okapi/facade/service/TenantModuleServiceTest.java
@@ -10,9 +10,9 @@ import static org.folio.test.TestConstants.OKAPI_AUTH_TOKEN;
 import static org.folio.test.TestConstants.TENANT_ID;
 import static org.folio.test.TestUtils.parse;
 import static org.folio.test.TestUtils.readString;
+import static org.folio.test.TestUtils.verifyNoMoreInteractions;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -31,6 +31,7 @@ import org.folio.okapi.facade.integration.mte.MgrTenantEntitlementsService;
 import org.folio.okapi.facade.utils.ModuleId;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,8 +74,9 @@ class TenantModuleServiceTest {
     when(folioContext.getAllHeaders()).thenReturn(Map.of());
   }
 
+  @AfterEach
   void tearDown() {
-    verifyNoMoreInteractions(entitlementService, folioContext);
+    verifyNoMoreInteractions(this);
   }
 
   @Test
@@ -83,6 +85,7 @@ class TenantModuleServiceTest {
 
     var expected = extractAllModuleDescriptors(testAppDescriptors, byModuleId());
     assertThat(found).containsExactlyElementsOf(expected);
+    verify(entitlementService).getTenantApplications(tenantId, OKAPI_AUTH_TOKEN);
   }
 
   @Test
@@ -104,6 +107,7 @@ class TenantModuleServiceTest {
 
     var expected = extractAllModuleDescriptors(testAppDescriptors, byModuleId());
     assertThat(found).containsExactlyElementsOf(expected);
+    verify(entitlementService).getTenantApplications(tenantId, OKAPI_AUTH_TOKEN);
   }
 
   @Test
@@ -113,6 +117,7 @@ class TenantModuleServiceTest {
 
     var expected = extractAllModuleDescriptors(testAppDescriptors, moduleNameIn(filter), byModuleId());
     assertThat(found).containsExactlyElementsOf(expected);
+    verify(entitlementService).getTenantApplications(tenantId, OKAPI_AUTH_TOKEN);
   }
 
   @Test
@@ -123,6 +128,7 @@ class TenantModuleServiceTest {
     var expected = extractAllModuleDescriptors(testAppDescriptors, moduleNameIn("mod-configuration", "mod-users"),
       byModuleId());
     assertThat(found).containsExactlyElementsOf(expected);
+    verify(entitlementService).getTenantApplications(tenantId, OKAPI_AUTH_TOKEN);
   }
 
   @Test
@@ -135,6 +141,7 @@ class TenantModuleServiceTest {
         "mod-password-validator", "mod-users-bl", "mod-users-keycloak"),
       byModuleId());
     assertThat(found).containsExactlyElementsOf(expected);
+    verify(entitlementService).getTenantApplications(tenantId, OKAPI_AUTH_TOKEN);
   }
 
   @Test
@@ -146,6 +153,7 @@ class TenantModuleServiceTest {
       moduleNameIn("mod-users-bl", "folio_stripes-core"),
       byModuleId());
     assertThat(found).containsExactlyElementsOf(expected);
+    verify(entitlementService).getTenantApplications(tenantId, OKAPI_AUTH_TOKEN);
   }
 
   @Test
@@ -157,6 +165,7 @@ class TenantModuleServiceTest {
       moduleNameIn("folio_authorization-policies"),
       byModuleId());
     assertThat(found).containsExactlyElementsOf(expected);
+    verify(entitlementService).getTenantApplications(tenantId, OKAPI_AUTH_TOKEN);
   }
 
   @Test
@@ -169,6 +178,7 @@ class TenantModuleServiceTest {
       moduleNameIn(filter),
       byModuleId());
     assertThat(found).containsExactlyElementsOf(expected);
+    verify(entitlementService).getTenantApplications(tenantId, OKAPI_AUTH_TOKEN);
   }
 
   @Test
@@ -179,6 +189,7 @@ class TenantModuleServiceTest {
 
     var expected = extractAllModuleDescriptors(testAppDescriptors, byModuleId().reversed());
     assertThat(found).containsExactlyElementsOf(expected);
+    verify(entitlementService).getTenantApplications(tenantId, OKAPI_AUTH_TOKEN);
   }
 
   @Test
@@ -189,6 +200,7 @@ class TenantModuleServiceTest {
 
     var expected = extractAllModuleDescriptors(testAppDescriptors, byModuleId());
     assertThat(found).containsExactlyElementsOf(expected);
+    verify(entitlementService).getTenantApplications(tenantId, OKAPI_AUTH_TOKEN);
   }
 
   @Test
@@ -198,6 +210,7 @@ class TenantModuleServiceTest {
     assertThatThrownBy(this::findAll)
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessage("unknown orderBy field: " + orderBy);
+    verify(entitlementService).getTenantApplications(tenantId, OKAPI_AUTH_TOKEN);
   }
 
   @Test
@@ -208,6 +221,7 @@ class TenantModuleServiceTest {
     assertThatThrownBy(this::findAll)
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessage("invalid order value: " + order);
+    verify(entitlementService).getTenantApplications(tenantId, OKAPI_AUTH_TOKEN);
   }
 
   private List<ModuleDescriptor> findAll() {

--- a/src/test/java/org/folio/okapi/facade/service/TenantModuleServiceTest.java
+++ b/src/test/java/org/folio/okapi/facade/service/TenantModuleServiceTest.java
@@ -10,12 +10,15 @@ import static org.folio.test.TestConstants.OKAPI_AUTH_TOKEN;
 import static org.folio.test.TestConstants.TENANT_ID;
 import static org.folio.test.TestUtils.parse;
 import static org.folio.test.TestUtils.readString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -67,7 +70,7 @@ class TenantModuleServiceTest {
   @BeforeEach
   void setUp() {
     when(folioContext.getToken()).thenReturn(OKAPI_AUTH_TOKEN);
-    when(entitlementService.getTenantApplications(tenantId, OKAPI_AUTH_TOKEN)).thenReturn(testAppDescriptors);
+    lenient().when(entitlementService.getTenantApplications(tenantId, OKAPI_AUTH_TOKEN)).thenReturn(testAppDescriptors);
   }
 
   @AfterEach
@@ -81,6 +84,18 @@ class TenantModuleServiceTest {
 
     var expected = extractAllModuleDescriptors(testAppDescriptors, byModuleId());
     assertThat(found).containsExactlyElementsOf(expected);
+  }
+
+  @Test
+  void findAll_positive_defaultParams_systemTokenExists() {
+    when(folioContext.getAllHeaders()).thenReturn(Map.of("x-system-token", List.of("systemToken")));
+    when(entitlementService.getTenantApplications(tenantId, "systemToken")).thenReturn(testAppDescriptors);
+    var found = findAll();
+
+    var expected = extractAllModuleDescriptors(testAppDescriptors, byModuleId());
+
+    assertThat(found).containsExactlyElementsOf(expected);
+    verify(entitlementService).getTenantApplications(tenantId, "systemToken");
   }
 
   @Test

--- a/src/test/java/org/folio/okapi/facade/service/TenantModuleServiceTest.java
+++ b/src/test/java/org/folio/okapi/facade/service/TenantModuleServiceTest.java
@@ -12,6 +12,7 @@ import static org.folio.test.TestUtils.parse;
 import static org.folio.test.TestUtils.readString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -29,9 +30,7 @@ import org.folio.common.domain.model.ModuleDescriptor;
 import org.folio.okapi.facade.integration.mte.MgrTenantEntitlementsService;
 import org.folio.okapi.facade.utils.ModuleId;
 import org.folio.spring.FolioExecutionContext;
-import org.folio.test.TestUtils;
 import org.folio.test.types.UnitTest;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,11 +70,11 @@ class TenantModuleServiceTest {
   void setUp() {
     when(folioContext.getToken()).thenReturn(OKAPI_AUTH_TOKEN);
     lenient().when(entitlementService.getTenantApplications(tenantId, OKAPI_AUTH_TOKEN)).thenReturn(testAppDescriptors);
+    when(folioContext.getAllHeaders()).thenReturn(Map.of());
   }
 
-  @AfterEach
   void tearDown() {
-    TestUtils.verifyNoMoreInteractions(this);
+    verifyNoMoreInteractions(entitlementService, folioContext);
   }
 
   @Test

--- a/src/test/java/org/folio/okapi/facade/utils/TokenUtilsTest.java
+++ b/src/test/java/org/folio/okapi/facade/utils/TokenUtilsTest.java
@@ -1,0 +1,64 @@
+package org.folio.okapi.facade.utils;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.test.types.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class TokenUtilsTest {
+
+  @Mock FolioExecutionContext folioContext;
+
+  @Test
+  void extractToken_positive_systemTokenExists() {
+    var token = "system-token";
+    when(folioContext.getAllHeaders()).thenReturn(Map.of("X-System-Token", List.of(token)));
+
+    var result = TokenUtils.extractToken(folioContext);
+
+    assertThat(result).isEqualTo(token);
+    verify(folioContext).getAllHeaders();
+    verify(folioContext).getToken();
+    verifyNoMoreInteractions(folioContext);
+  }
+
+  @Test
+  void extractToken_positive_userTokenExists() {
+    var token = "user-token";
+    when(folioContext.getAllHeaders()).thenReturn(Map.of());
+    when(folioContext.getToken()).thenReturn(token);
+
+    var result = TokenUtils.extractToken(folioContext);
+
+    assertThat(result).isEqualTo(token);
+    verify(folioContext).getAllHeaders();
+    verify(folioContext).getToken();
+    verifyNoMoreInteractions(folioContext);
+  }
+
+  @Test
+  void extractToken_positive_bothTokensExist() {
+    var systemToken = "system-token";
+    var userToken = "user-token";
+    when(folioContext.getAllHeaders()).thenReturn(Map.of("X-System-Token", List.of(systemToken)));
+    when(folioContext.getToken()).thenReturn(userToken);
+
+    var result = TokenUtils.extractToken(folioContext);
+
+    assertThat(result).isEqualTo(systemToken);
+    verify(folioContext).getAllHeaders();
+    verify(folioContext).getToken();
+    verifyNoMoreInteractions(folioContext);
+  }
+}


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODOKAPFAC-11

The PR fixes an error in okapi-facade while retrieving application data with expired user token. 

## Approach

- add system token (`x-system-token`) header if exists
- add test


## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
